### PR TITLE
Change Mikrokosmos (II) info

### DIFF
--- a/public/data/modules.json
+++ b/public/data/modules.json
@@ -502,14 +502,14 @@
     "function": [
       "Interface"
     ],
-    "name": "Mikrokosmos",
-    "description": "Kosmo format version of Music Thing Modular's Mikrophonie",
+    "name": "Mikrokosmos II",
+    "description": "Piezo element amplifier inspired by Music Thing Modular's Mikrophonie",
     "width": 2.5,
     "type": [
       "PCB + Panel"
     ],
-    "link": "https://github.com/holmesrichards/Mikrokosmos",
-    "imageLink": "https://github.com/holmesrichards/Mikrokosmos/raw/master/Images/IMG_6220.JPG?raw=true"
+    "link": "https://github.com/holmesrichards/mikrokosmosii",
+    "imageLink": "https://github.com/holmesrichards/mikrokosmosii/raw/main/Images/mikrokosmos.jpg?raw=true"
   },
   {
     "id": "3fe8c809-22f9-4a46-bf47-9762e0d9965e",


### PR DESCRIPTION
This changes the information for Mikrokosmos to point to a different repo with a new version that supersedes the old one. I did not change the ID, wasn't sure if that was needed or not.
